### PR TITLE
Remove unused Vault URI from development profile configuration

### DIFF
--- a/unit-of-measure-service-dev.yml
+++ b/unit-of-measure-service-dev.yml
@@ -4,7 +4,6 @@ spring:
   cloud:
     vault:
       application-name: ${spring.application.name}
-      uri: http://localhost:8200
   datasource:
     url: jdbc:postgresql://localhost:5432/unit_of_measure_db
     driver-class-name: org.postgresql.Driver


### PR DESCRIPTION
This pull request makes a minor configuration change to the development YAML for the unit-of-measure service. The Vault URI setting under the `spring.cloud.vault` section has been removed, which means the service will now rely on the default Vault URI or another configuration source.

* Removed the explicit `uri` setting for Vault from `unit-of-measure-service-dev.yml` under `spring.cloud.vault`, so Vault connection will use the default or environment-provided URI.