### PR TITLE
Add development profile description to unit-of-measure-service-dev.yml

### DIFF
--- a/unit-of-measure-service-dev.yml
+++ b/unit-of-measure-service-dev.yml
@@ -24,3 +24,6 @@ eureka:
       environment: development
       region: us-east
     prefer-ip-address: true
+
+uom:
+  property: This is the development profile for Unit of Measure Service


### PR DESCRIPTION
This pull request introduces a configuration update to the development profile for the Unit of Measure Service. The main change is the addition of a new property under the `uom` section in the `unit-of-measure-service-dev.yml` file.

Configuration update:

* Added a new `uom.property` entry with the value "This is the development profile for Unit of Measure Service" to the development configuration file `unit-of-measure-service-dev.yml`.