### PR TITLE
Remove production profile configuration from unit-of-measure-service-…

### DIFF
--- a/unit-of-measure-service-prod.yml
+++ b/unit-of-measure-service-prod.yml
@@ -1,3 +1,0 @@
-spring:
-  application:
-    name: unit-of-measure-service


### PR DESCRIPTION
This pull request makes a small change by removing the Spring application name configuration from the `unit-of-measure-service-prod.yml` 