### PR TITLE
Add production profile configuration for Unit of Measure Service

### DIFF
--- a/unit-of-measure-service-prod.yml
+++ b/unit-of-measure-service-prod.yml
@@ -1,0 +1,2 @@
+uom:
+  property: This is the Production profile for Unit of Measure Service


### PR DESCRIPTION
This pull request adds a configuration entry for the production profile of the Unit of Measure Service.

* Configuration: Added a `uom` property with a description for the production profile in `unit-of-measure-service-prod.yml`.