### PR TITLE
Refactor profile descriptions in configuration files for consistency

### DIFF
--- a/unit-of-measure-service-dev.yml
+++ b/unit-of-measure-service-dev.yml
@@ -26,4 +26,4 @@ eureka:
     prefer-ip-address: true
 
 uom:
-  property: This is the development profile for Unit of Measure Service
+  property: This is the development profile

--- a/unit-of-measure-service-prod.yml
+++ b/unit-of-measure-service-prod.yml
@@ -1,2 +1,2 @@
 uom:
-  property: This is the Production profile for Unit of Measure Service
+  property: This is the production profile

--- a/unit-of-measure-service-test.yml
+++ b/unit-of-measure-service-test.yml
@@ -24,4 +24,4 @@ logging:
     org.hibernate.SQL: DEBUG
     org.hibernate.type.descriptor.sql.BasicBinder: TRACE
 uom:
-  property: This is the test profile for Unit of Measure Service
+  property: This is the test profile


### PR DESCRIPTION
This pull request makes minor updates to the profile descriptions in the configuration files for the Unit of Measure Service. The changes simplify the wording of the `uom.property` values in each environment profile.

Configuration updates:

* Updated the `uom.property` value in `unit-of-measure-service-dev.yml` to a shorter description for the development profile.
* Updated the `uom.property` value in `unit-of-measure-service-prod.yml` to a shorter description for the production profile.
* Updated the `uom.property` value in `unit-of-measure-service-test.yml` to a shorter description for the test profile.