### PR TITLE
Feature/inventory service setup properties

### DIFF
--- a/inventory-service-dev.yml
+++ b/inventory-service-dev.yml
@@ -1,0 +1,29 @@
+server:
+  port: 0
+spring:
+  cloud:
+    vault:
+      application-name: ${spring.application.name}
+  datasource:
+    url: jdbc:postgresql://localhost:5432/inventory_db
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:8761/eureka/
+  instance:
+    instance-id: ${spring.application.name}:${random.uuid}
+    metadata-map:
+      version: 1.0.0
+      environment: development
+      region: us-east
+    prefer-ip-address: true
+inventory:
+
+  property: Inventory Service - this is the development profile

--- a/inventory-service-prod.yml
+++ b/inventory-service-prod.yml
@@ -1,0 +1,2 @@
+inventory:
+  property: Inventory Service - this is the production profile

--- a/inventory-service-test.yml
+++ b/inventory-service-test.yml
@@ -1,0 +1,28 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+  sql:
+    init:
+      mode: always
+      platform: h2
+logging:
+  level:
+    org.hibernate.SQL: DEBUG
+    org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+
+inventory:
+  property: Inventory Service - this is the test profile


### PR DESCRIPTION
This pull request adds new configuration files for the inventory service, providing distinct settings for development, test, and production environments. These configurations help ensure the service runs with the appropriate database, service discovery, and environment-specific properties.

**Environment-specific configuration:**

* Added `inventory-service-dev.yml` with development settings, including PostgreSQL datasource, Eureka service discovery, Vault integration, and metadata for the dev environment.
* Added `inventory-service-test.yml` with test settings, using an H2 in-memory database, Hibernate configuration for testing, and enabled H2 console for easier debugging.
* Added `inventory-service-prod.yml` with a property indicating the production profile.