### PR TITLE
Feature/message broker setup

### DIFF
--- a/inventory-service-dev.yml
+++ b/inventory-service-dev.yml
@@ -13,6 +13,9 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+  rabbitmq:
+    host: localhost
+    port: 5672
 eureka:
   client:
     service-url:

--- a/unit-of-measure-service-dev.yml
+++ b/unit-of-measure-service-dev.yml
@@ -13,6 +13,9 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+  rabbitmq:
+    host: localhost
+    port: 5672
 eureka:
   client:
     service-url:


### PR DESCRIPTION
This pull request adds RabbitMQ configuration to the development YAML files for both the inventory and unit-of-measure services. This ensures that both services are set up to connect to a local RabbitMQ instance during development.

Configuration updates:

* Added `rabbitmq` settings (`host: localhost`, `port: 5672`) under the `spring` section in `inventory-service-dev.yml` to enable RabbitMQ connectivity for the inventory service.
* Added `rabbitmq` settings (`host: localhost`, `port: 5672`) under the `spring` section in `unit-of-measure-service-dev.yml` to enable RabbitMQ connectivity for the unit-of-measure service.